### PR TITLE
Correcting javadoc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,9 @@ Okta's Authentication API is built around a [state machine](https://developer.ok
 
 # Usage
 
-<!--
 ## Javadocs
 
 You can see this project's Javadocs at https://developer.okta.com/okta-authn-java/ 
--->
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Okta's Authentication API is built around a [state machine](https://developer.ok
 
 # Usage
 
+<!--
 ## Javadocs
 
 You can see this project's Javadocs at https://developer.okta.com/okta-authn-sdk-java/ 
+-->
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Okta's Authentication API is built around a [state machine](https://developer.ok
 <!--
 ## Javadocs
 
-You can see this project's Javadocs at https://developer.okta.com/okta-authn-sdk-java/ 
+You can see this project's Javadocs at https://developer.okta.com/okta-authn-java/ 
 -->
 
 ## Dependencies


### PR DESCRIPTION
Javadocs are now live at d.o.c