### PR TITLE
Rename pollFactor to verifyActivation and added a verifyFactor method used while polling at factor

### DIFF
--- a/api/src/main/java/com/okta/authn/sdk/AuthenticationStateHandler.java
+++ b/api/src/main/java/com/okta/authn/sdk/AuthenticationStateHandler.java
@@ -51,7 +51,7 @@ import com.okta.authn.sdk.resource.AuthenticationResponse;
  */
 public interface AuthenticationStateHandler {
 
-    void handleUnauthenticated(AuthenticationResponse typedUnauthenticatedResponse);
+    void handleUnauthenticated(AuthenticationResponse unauthenticatedResponse);
 
     void handlePasswordWarning(AuthenticationResponse passwordWarning);
 
@@ -75,5 +75,5 @@ public interface AuthenticationStateHandler {
 
     void handleSuccess(AuthenticationResponse successResponse);
 
-    void handleUnknown(AuthenticationResponse typedUnknownResponse);
+    void handleUnknown(AuthenticationResponse unknownResponse);
 }

--- a/api/src/main/java/com/okta/authn/sdk/client/AuthenticationClient.java
+++ b/api/src/main/java/com/okta/authn/sdk/client/AuthenticationClient.java
@@ -316,6 +316,19 @@ public interface AuthenticationClient {
     AuthenticationResponse verifyFactor(String factorId, VerifyFactorRequest request, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
+     * Verifies the state of a factor. Some factors (Push, Duo, etc) depend on a user action, this method can be used to poll the state of
+     * the a factor and transition to the next state when completed.
+     *
+     * @param factorId id of factor returned from enrollment
+     * @param stateToken state token for current transaction
+     * @param stateHandler State handler that handles the resulting status change corresponding to the Okta authentication state machine
+     * @return An authentication response
+     * @throws AuthenticationException any other authentication related error
+     */
+    @ApiReference(path = "/api/v1/authn/factors/{factorId}/verify", href = "https://developer.okta.com/docs/api/resources/authn#poll-for-push-factor-activation")
+    AuthenticationResponse verifyFactor(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
+
+    /**
      * Requests a challenge factor be sent to the user via the corresponding {code}factorId{code}.
      *
      * @param factorId id of factor returned from enrollment
@@ -366,16 +379,16 @@ public interface AuthenticationClient {
     AuthenticationResponse resendVerifyFactor(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
-     * Polls for state of factor. Some factors (Push, Duo, etc) depend on a user action, this method can be used to poll the state of
-     * the a factor and transition to the next state when completed.
+     * Returns the state of factor's activation. Some factors (Push, Duo, etc) depend on a user action, this method can
+     * be used to poll the state of the a factor's activation and transition to the next state when completed.
      *
      * @param stateToken state token for current transaction
      * @param stateHandler State handler that handles the resulting status change corresponding to the Okta authentication state machine
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/factors/{factorId}/lifecycle/activate/poll", href = "https://developer.okta.com/docs/api/resources/authn.html#poll-for-push-factor-activation")
-    AuthenticationResponse pollFactor(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
+    @ApiReference(path = "/api/v1/authn/factors/{factorId}/lifecycle/activate/poll", href = "https://developer.okta.com/docs/api/resources/authn#poll-for-push-factor-activation")
+    AuthenticationResponse getFactorActivationStatus(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
      * Validates a recovery token that was distributed to the end user to continue the recovery transaction.

--- a/api/src/main/java/com/okta/authn/sdk/client/AuthenticationClient.java
+++ b/api/src/main/java/com/okta/authn/sdk/client/AuthenticationClient.java
@@ -89,7 +89,7 @@ public interface AuthenticationClient {
      * @throws com.okta.authn.sdk.AuthenticationFailureException when username or password are invalid
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn", href = "https://developer.okta.com/docs/api/resources/authn.html#primary-authentication")
+    @ApiReference(path = "/api/v1/authn", href = "https://developer.okta.com/docs/api/resources/authn#primary-authentication")
     AuthenticationResponse authenticate(String username, char[] password, String relayState, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -102,7 +102,7 @@ public interface AuthenticationClient {
      * @throws com.okta.authn.sdk.AuthenticationFailureException when username or password are invalid
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn", href = "https://developer.okta.com/docs/api/resources/authn.html#primary-authentication")
+    @ApiReference(path = "/api/v1/authn", href = "https://developer.okta.com/docs/api/resources/authn#primary-authentication")
     AuthenticationResponse authenticate(AuthenticationRequest request, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -117,7 +117,7 @@ public interface AuthenticationClient {
      * requirements of the password policy
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/credentials/change_password", href = "https://developer.okta.com/docs/api/resources/authn.html#change-password")
+    @ApiReference(path = "/api/v1/authn/credentials/change_password", href = "https://developer.okta.com/docs/api/resources/authn#change-password")
     AuthenticationResponse changePassword(char[] oldPassword, char[] newPassword, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -130,7 +130,7 @@ public interface AuthenticationClient {
      * requirements of the password policy
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/credentials/change_password", href = "https://developer.okta.com/docs/api/resources/authn.html#change-password")
+    @ApiReference(path = "/api/v1/authn/credentials/change_password", href = "https://developer.okta.com/docs/api/resources/authn#change-password")
     AuthenticationResponse changePassword(ChangePasswordRequest changePasswordRequest, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -144,7 +144,7 @@ public interface AuthenticationClient {
      * requirements of the password policy
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/credentials/reset_password", href = "https://developer.okta.com/docs/api/resources/authn.html#reset-password")
+    @ApiReference(path = "/api/v1/authn/credentials/reset_password", href = "https://developer.okta.com/docs/api/resources/authn#reset-password")
     AuthenticationResponse resetPassword(char[] newPassword, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -157,7 +157,7 @@ public interface AuthenticationClient {
      * requirements of the password policy
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/credentials/reset_password", href = "https://developer.okta.com/docs/api/resources/authn.html#reset-password")
+    @ApiReference(path = "/api/v1/authn/credentials/reset_password", href = "https://developer.okta.com/docs/api/resources/authn#reset-password")
     AuthenticationResponse resetPassword(ChangePasswordRequest changePasswordRequest, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -172,7 +172,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/factors", href = "https://developer.okta.com/docs/api/resources/authn.html#enroll-factor")
+    @ApiReference(path = "/api/v1/authn/factors", href = "https://developer.okta.com/docs/api/resources/authn#enroll-factor")
     AuthenticationResponse enrollFactor(FactorType factorType, FactorProvider factorProvider, FactorProfile factorProfile, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -184,7 +184,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/factors", href = "https://developer.okta.com/docs/api/resources/authn.html#enroll-factor")
+    @ApiReference(path = "/api/v1/authn/factors", href = "https://developer.okta.com/docs/api/resources/authn#enroll-factor")
     AuthenticationResponse enrollFactor(FactorEnrollRequest factorEnrollRequest, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -196,7 +196,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/recovery/password", href = "https://developer.okta.com/docs/api/resources/authn.html#recovery-operations")
+    @ApiReference(path = "/api/v1/authn/recovery/password", href = "https://developer.okta.com/docs/api/resources/authn#recovery-operations")
     AuthenticationResponse recoverPassword(String username, FactorType factorType, String relayState, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -206,7 +206,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/recovery/password", href = "https://developer.okta.com/docs/api/resources/authn.html#recovery-operations")
+    @ApiReference(path = "/api/v1/authn/recovery/password", href = "https://developer.okta.com/docs/api/resources/authn#recovery-operations")
     AuthenticationResponse recoverPassword(RecoverPasswordRequest request, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -219,7 +219,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/recovery/unlock", href = "https://developer.okta.com/docs/api/resources/authn.html#unlock-account")
+    @ApiReference(path = "/api/v1/authn/recovery/unlock", href = "https://developer.okta.com/docs/api/resources/authn#unlock-account")
     AuthenticationResponse unlockAccount(String username, FactorType factorType, String relayState, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -230,7 +230,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/recovery/unlock", href = "https://developer.okta.com/docs/api/resources/authn.html#unlock-account")
+    @ApiReference(path = "/api/v1/authn/recovery/unlock", href = "https://developer.okta.com/docs/api/resources/authn#unlock-account")
     AuthenticationResponse unlockAccount(UnlockAccountRequest request, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -244,7 +244,7 @@ public interface AuthenticationClient {
      * @throws com.okta.authn.sdk.InvalidRecoveryAnswerException thrown when the answer is invalid
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/recovery/answer", href = "https://developer.okta.com/docs/api/resources/authn.html#answer-recovery-question")
+    @ApiReference(path = "/api/v1/authn/recovery/answer", href = "https://developer.okta.com/docs/api/resources/authn#answer-recovery-question")
     AuthenticationResponse answerRecoveryQuestion(String answer, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -257,7 +257,7 @@ public interface AuthenticationClient {
      * @throws com.okta.authn.sdk.InvalidRecoveryAnswerException thrown when the answer is invalid
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/recovery/answer", href = "https://developer.okta.com/docs/api/resources/authn.html#answer-recovery-question")
+    @ApiReference(path = "/api/v1/authn/recovery/answer", href = "https://developer.okta.com/docs/api/resources/authn#answer-recovery-question")
     AuthenticationResponse answerRecoveryQuestion(RecoveryQuestionAnswerRequest request, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -268,7 +268,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/previous", href = "https://developer.okta.com/docs/api/resources/authn.html#previous-transaction-state")
+    @ApiReference(path = "/api/v1/authn/previous", href = "https://developer.okta.com/docs/api/resources/authn#previous-transaction-state")
     AuthenticationResponse previous(String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -279,7 +279,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/skip", href = "https://developer.okta.com/docs/api/resources/authn.html#skip-transaction-state")
+    @ApiReference(path = "/api/v1/authn/skip", href = "https://developer.okta.com/docs/api/resources/authn#skip-transaction-state")
     AuthenticationResponse skip(String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -288,7 +288,7 @@ public interface AuthenticationClient {
      * @param stateToken state token for current transaction
      * @return An authentication response
      */
-    @ApiReference(path = "/api/v1/authn/cancel", href = "https://developer.okta.com/docs/api/resources/authn.html#cancel-transaction")
+    @ApiReference(path = "/api/v1/authn/cancel", href = "https://developer.okta.com/docs/api/resources/authn#cancel-transaction")
     AuthenticationResponse cancel(String stateToken);
 
     /**
@@ -300,7 +300,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/factors/{factorId}/lifecycle/activate", href = "https://developer.okta.com/docs/api/resources/authn.html#activate-factor")
+    @ApiReference(path = "/api/v1/authn/factors/{factorId}/lifecycle/activate", href = "https://developer.okta.com/docs/api/resources/authn#activate-factor")
     AuthenticationResponse activateFactor(String factorId, ActivateFactorRequest request, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -312,7 +312,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/factors/{factorId}/verify", href = "https://developer.okta.com/docs/api/resources/authn.html#verify-factor")
+    @ApiReference(path = "/api/v1/authn/factors/{factorId}/verify", href = "https://developer.okta.com/docs/api/resources/authn#verify-factor")
     AuthenticationResponse verifyFactor(String factorId, VerifyFactorRequest request, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -325,7 +325,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/factors/{factorId}/verify", href = "https://developer.okta.com/docs/api/resources/authn#poll-for-push-factor-activation")
+    @ApiReference(path = "/api/v1/authn/factors/{factorId}/verify", href = "https://developer.okta.com/docs/api/resources/authn#poll-for-push-factor-activation") //TODO: fix link
     AuthenticationResponse verifyFactor(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -337,7 +337,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/factors/{factorId}/verify", href = "https://developer.okta.com/docs/api/resources/authn.html#verify-sms-factor")
+    @ApiReference(path = "/api/v1/authn/factors/{factorId}/verify", href = "https://developer.okta.com/docs/api/resources/authn#verify-sms-factor")
     AuthenticationResponse challengeFactor(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -349,7 +349,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/recovery/factors/{factorType}/verify", href = "https://developer.okta.com/docs/api/resources/authn.html#verify-recovery-factor")
+    @ApiReference(path = "/api/v1/authn/recovery/factors/{factorType}/verify", href = "https://developer.okta.com/docs/api/resources/authn#verify-recovery-factor")
     AuthenticationResponse verifyUnlockAccount(FactorType factorType, VerifyRecoveryRequest request, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
@@ -388,7 +388,7 @@ public interface AuthenticationClient {
      * @throws AuthenticationException any other authentication related error
      */
     @ApiReference(path = "/api/v1/authn/factors/{factorId}/lifecycle/activate/poll", href = "https://developer.okta.com/docs/api/resources/authn#poll-for-push-factor-activation")
-    AuthenticationResponse getFactorActivationStatus(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
+    AuthenticationResponse verifyActivation(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
      * Validates a recovery token that was distributed to the end user to continue the recovery transaction.
@@ -398,6 +398,6 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/recovery/token", href = "https://developer.okta.com/docs/api/resources/authn.html#verify-recovery-token")
+    @ApiReference(path = "/api/v1/authn/recovery/token", href = "https://developer.okta.com/docs/api/resources/authn#verify-recovery-token")
     AuthenticationResponse verifyRecoveryToken(String recoveryToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 }

--- a/api/src/main/java/com/okta/authn/sdk/client/AuthenticationClient.java
+++ b/api/src/main/java/com/okta/authn/sdk/client/AuthenticationClient.java
@@ -325,7 +325,7 @@ public interface AuthenticationClient {
      * @return An authentication response
      * @throws AuthenticationException any other authentication related error
      */
-    @ApiReference(path = "/api/v1/authn/factors/{factorId}/verify", href = "https://developer.okta.com/docs/api/resources/authn#poll-for-push-factor-activation") //TODO: fix link
+    @ApiReference(path = "/api/v1/authn/factors/{factorId}/verify", href = "https://developer.okta.com/docs/api/resources/authn#verify-push-factor")
     AuthenticationResponse verifyFactor(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**

--- a/impl/src/main/java/com/okta/authn/sdk/impl/client/DefaultAuthenticationClient.java
+++ b/impl/src/main/java/com/okta/authn/sdk/impl/client/DefaultAuthenticationClient.java
@@ -238,7 +238,7 @@ public class DefaultAuthenticationClient extends BaseClient implements Authentic
     }
 
     @Override
-    public AuthenticationResponse getFactorActivationStatus(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException {
+    public AuthenticationResponse verifyActivation(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException {
         return doPost("/api/v1/authn/factors/" + factorId + "/lifecycle/activate/poll", toRequest(stateToken), stateHandler);
     }
 

--- a/impl/src/main/java/com/okta/authn/sdk/impl/client/DefaultAuthenticationClient.java
+++ b/impl/src/main/java/com/okta/authn/sdk/impl/client/DefaultAuthenticationClient.java
@@ -145,6 +145,12 @@ public class DefaultAuthenticationClient extends BaseClient implements Authentic
     }
 
     @Override
+    public AuthenticationResponse verifyFactor(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException {
+        // same request body as challengeFactor
+        return challengeFactor(factorId, stateToken, stateHandler);
+    }
+
+    @Override
     public AuthenticationResponse verifyFactor(String factorId, VerifyFactorRequest request, AuthenticationStateHandler stateHandler) throws AuthenticationException {
         return doPost("/api/v1/authn/factors/" + factorId + "/verify", request, stateHandler);
     }
@@ -232,7 +238,7 @@ public class DefaultAuthenticationClient extends BaseClient implements Authentic
     }
 
     @Override
-    public AuthenticationResponse pollFactor(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException {
+    public AuthenticationResponse getFactorActivationStatus(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException {
         return doPost("/api/v1/authn/factors/" + factorId + "/lifecycle/activate/poll", toRequest(stateToken), stateHandler);
     }
 

--- a/impl/src/test/groovy/com/okta/authn/sdk/impl/client/DefaultAuthenticationClientTest.groovy
+++ b/impl/src/test/groovy/com/okta/authn/sdk/impl/client/DefaultAuthenticationClientTest.groovy
@@ -25,12 +25,10 @@ import com.okta.authn.sdk.resource.AuthenticationStatus
 import com.okta.authn.sdk.resource.VerifyPassCodeFactorRequest
 import com.okta.authn.sdk.resource.VerifyRecoveryRequest
 import com.okta.sdk.client.AuthenticationScheme
-import com.okta.sdk.impl.cache.DisabledCacheManager
 import com.okta.sdk.impl.config.ClientConfiguration
 import com.okta.sdk.impl.http.MediaType
 import com.okta.sdk.impl.http.Request
 import com.okta.sdk.impl.http.RequestExecutor
-import com.okta.sdk.impl.http.authc.DefaultRequestAuthenticatorFactory
 import com.okta.sdk.impl.http.support.DefaultResponse
 import com.okta.sdk.impl.util.DefaultBaseUrlResolver
 import com.okta.sdk.resource.ResourceException
@@ -195,7 +193,7 @@ class DefaultAuthenticationClientTest {
         ))
 
         def stateHandler = mock(AuthenticationStateHandler)
-        AuthenticationResponse response = client.getFactorActivationStatus(factorId, "stateToken1", stateHandler)
+        AuthenticationResponse response = client.verifyActivation(factorId, "stateToken1", stateHandler)
         verify(stateHandler).handleMfaEnrollActivate(response)
         assertThat response.factorResult, is("WAITING")
     }

--- a/impl/src/test/groovy/com/okta/authn/sdk/impl/client/DefaultAuthenticationClientTest.groovy
+++ b/impl/src/test/groovy/com/okta/authn/sdk/impl/client/DefaultAuthenticationClientTest.groovy
@@ -195,7 +195,7 @@ class DefaultAuthenticationClientTest {
         ))
 
         def stateHandler = mock(AuthenticationStateHandler)
-        AuthenticationResponse response = client.pollFactor(factorId, "stateToken1", stateHandler)
+        AuthenticationResponse response = client.getFactorActivationStatus(factorId, "stateToken1", stateHandler)
         verify(stateHandler).handleMfaEnrollActivate(response)
         assertThat response.factorResult, is("WAITING")
     }
@@ -303,6 +303,27 @@ class DefaultAuthenticationClientTest {
 
         def stateHandler = mock(AuthenticationStateHandler)
         AuthenticationResponse response = client.challengeFactor(factorId, "stateToken1", stateHandler)
+        verify(stateHandler).handleMfaChallenge(response)
+    }
+
+    @Test
+    void verifyFactorForStatusTest() {
+        def client = createClient("verifyFactorForStatusTest")
+        StubRequestExecutor requestExecutor = client.getRequestExecutor()
+
+        def factorId = "factor321"
+        requestExecutor.requestMatchers.add(bodyMatches(
+            jsonObject()
+                .where("stateToken", is(jsonText("stateToken1")))
+        ))
+
+        requestExecutor.requestMatchers.add(
+            urlMatches(
+                endsWith("/api/v1/authn/factors/${factorId}/verify")
+        ))
+
+        def stateHandler = mock(AuthenticationStateHandler)
+        AuthenticationResponse response = client.verifyFactor(factorId, "stateToken1", stateHandler)
         verify(stateHandler).handleMfaChallenge(response)
     }
 

--- a/impl/src/test/resources/com/okta/authn/sdk/impl/client/DefaultAuthenticationClientTest/verifyFactorForStatusTest/api/v1/authn/factors/factor321/verify.json
+++ b/impl/src/test/resources/com/okta/authn/sdk/impl/client/DefaultAuthenticationClientTest/verifyFactorForStatusTest/api/v1/authn/factors/factor321/verify.json
@@ -1,0 +1,69 @@
+{
+  "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb",
+  "expiresAt": "2015-11-03T10:15:57.000Z",
+  "status": "MFA_CHALLENGE",
+  "relayState": "/myapp/some/deep/link/i/want/to/return/to",
+  "factorResult": "REJECTED",
+  "_embedded": {
+    "user": {
+      "id": "00ub0oNGTSWTBKOLGLNR",
+      "passwordChanged": "2015-09-08T20:14:45.000Z",
+      "profile": {
+        "login": "dade.murphy@example.com",
+        "firstName": "Dade",
+        "lastName": "Murphy",
+        "locale": "en_US",
+        "timeZone": "America/Los_Angeles"
+      }
+    },
+    "factors": {
+      "id": "opfh52xcuft3J4uZc0g3",
+      "factorType": "push",
+      "provider": "OKTA",
+      "profile": {
+        "deviceType": "SmartPhone_IPhone",
+        "name": "Gibson",
+        "platform": "IOS",
+        "version": "9.0"
+      }
+    }
+  },
+  "_links": {
+    "next": {
+      "name": "verify",
+      "href": "https://dev-259824.oktapreview.com/api/v1/authn/factors/opfh52xcuft3J4uZc0g3/verify",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    },
+    "cancel": {
+      "href": "https://dev-259824.oktapreview.com/api/v1/authn/cancel",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    },
+    "prev": {
+      "href": "https://dev-259824.oktapreview.com/api/v1/authn/previous",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    },
+    "resend": [
+      {
+        "name": "push",
+        "href": "https://dev-259824.oktapreview.com/api/v1/authn/factors/opfh52xcuft3J4uZc0g3/verify/resend",
+        "hints": {
+          "allow": [
+            "POST"
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The method name previously matched the REST endpoint and doc names this was both incorrect and confusing.
Incorrect because this was only the "poll for activation" endpoint.  Confusing because the method itself didn't actually do any polling, this method (like a few others) is used during a polling action

Fixes: #18