### PR TITLE
Remove dead dependencies

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -80,17 +80,5 @@
             <version>3.0.7</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.twilio.sdk</groupId>
-            <artifactId>twilio</artifactId>
-            <version>7.18.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.telesign</groupId>
-            <artifactId>telesign</artifactId>
-            <version>2.2.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
These were never actually used, I attempted to use both twilio and telesign to test SMS factors,
but Okta's SMS messages are sent from shortcodes which cannot be received by
either service (as they are meant for end user devices).