### PR TITLE
Creates an android module to wrap the dependencies needed to run on android

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-Present Okta, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.okta.authn.sdk</groupId>
+        <artifactId>okta-authn-parent</artifactId>
+        <version>1.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>okta-authn-sdk-android</artifactId>
+    <name>Okta Java Authn SDK :: Android</name>
+    <description>
+        A dependency wrapper for all of the libraries needed to use the Okta Auth SDK on Android.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.okta.sdk</groupId>
+            <artifactId>okta-sdk-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.okta.sdk</groupId>
+            <artifactId>okta-sdk-impl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.okta.sdk</groupId>
+            <artifactId>okta-sdk-okhttp</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -65,14 +65,13 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
+        
+        <!-- Test deps -->
         <dependency>
             <groupId>com.okta.sdk</groupId>
             <artifactId>okta-sdk-httpclient</artifactId>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
-        
-        <!-- Test deps -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>14</version>
+        <version>17</version>
         <relativePath>../okta-java-parent</relativePath>
     </parent>
 
@@ -41,6 +41,7 @@
     <modules>
         <module>api</module>
         <module>impl</module>
+        <module>android</module>
         <module>examples/shiro-mustache</module>
         <module>examples/doc-examples</module>
         <module>integration-tests</module>


### PR DESCRIPTION
Of note this REMOVES the direct dependency on http client, so downstream consumers will need to add a dep on httpclient or okhttp (this is already in the readme)

Fixes: #64