### PR TITLE
Added functionality to retrieve correct answer from EmbeddedResponse …

### DIFF
--- a/api/src/main/java/com/okta/authn/sdk/resource/AuthenticationResponse.java
+++ b/api/src/main/java/com/okta/authn/sdk/resource/AuthenticationResponse.java
@@ -49,6 +49,8 @@ public interface AuthenticationResponse extends ExtensibleResource {
 
     String getRecoveryType();
 
+    Integer getCorrectAnswer();
+
     Map<String, Object> getEmbedded();
 
     Map<String, Link> getLinks();

--- a/impl/src/main/java/com/okta/authn/sdk/impl/resource/DefaultAuthenticationResponse.java
+++ b/impl/src/main/java/com/okta/authn/sdk/impl/resource/DefaultAuthenticationResponse.java
@@ -63,10 +63,12 @@ public class DefaultAuthenticationResponse extends AbstractResource implements A
 
     private static final MapProperty LINKS_PROPERTY = new MapProperty("_links");
 
+    private static final StringProperty CORRECT_ANSWER_PROPERTY = new StringProperty("correctAnswer");
     // Nested under _embedded
     private static final StringProperty NESTED__USER_PROPERTY = new StringProperty("user");
     private static final StringProperty NESTED__FACTORS_PROPERTY = new StringProperty("factors");
     private static final StringProperty NESTED__FACTOR_PROPERTY = new StringProperty("factor");
+    private static final StringProperty NESTED__CHALLENGE_PROPERTY = new StringProperty("challenge");
 
     public DefaultAuthenticationResponse(InternalDataStore dataStore, Map<String, Object> properties) {
         super(dataStore, properties);
@@ -193,5 +195,23 @@ public class DefaultAuthenticationResponse extends AbstractResource implements A
             }
         }
         return result;
+    }
+
+    @Override
+    public Integer getCorrectAnswer() {
+        Map<String, Object> rawFactor = (Map<String, Object>) getEmbedded().get(NESTED__FACTOR_PROPERTY.getName());
+
+        if (rawFactor != null && rawFactor.containsKey(EMBEDDED_PROPERTY.getName())) {
+            Map<String, Object> challengeFactorEmbedded = (Map<String, Object>) rawFactor.get(EMBEDDED_PROPERTY.getName());
+
+            if (challengeFactorEmbedded != null && challengeFactorEmbedded.containsKey(NESTED__CHALLENGE_PROPERTY.getName())) {
+                Map<String, Object> challenge = (Map<String, Object>) challengeFactorEmbedded.get(NESTED__CHALLENGE_PROPERTY.getName());
+
+                if (challenge != null && challenge.containsKey(CORRECT_ANSWER_PROPERTY.getName())) {
+                    return (Integer) challenge.get(CORRECT_ANSWER_PROPERTY.getName());
+                }
+            }
+        }
+        return null;
     }
 }

--- a/impl/src/main/java/com/okta/authn/sdk/impl/resource/DefaultAuthenticationResponse.java
+++ b/impl/src/main/java/com/okta/authn/sdk/impl/resource/DefaultAuthenticationResponse.java
@@ -24,6 +24,7 @@ import com.okta.sdk.impl.ds.InternalDataStore;
 import com.okta.sdk.impl.resource.AbstractResource;
 import com.okta.sdk.impl.resource.DateProperty;
 import com.okta.sdk.impl.resource.EnumProperty;
+import com.okta.sdk.impl.resource.IntegerProperty; 
 import com.okta.sdk.impl.resource.MapProperty;
 import com.okta.sdk.impl.resource.Property;
 import com.okta.sdk.impl.resource.StringProperty;
@@ -63,7 +64,8 @@ public class DefaultAuthenticationResponse extends AbstractResource implements A
 
     private static final MapProperty LINKS_PROPERTY = new MapProperty("_links");
 
-    private static final StringProperty CORRECT_ANSWER_PROPERTY = new StringProperty("correctAnswer");
+    private static final IntegerProperty CORRECT_ANSWER_PROPERTY = new IntegerProperty("correctAnswer");
+    
     // Nested under _embedded
     private static final StringProperty NESTED__USER_PROPERTY = new StringProperty("user");
     private static final StringProperty NESTED__FACTORS_PROPERTY = new StringProperty("factors");
@@ -90,7 +92,8 @@ public class DefaultAuthenticationResponse extends AbstractResource implements A
             FACTOR_TYPE_PROPERTY,
             RECOVERY_TYPE_PROPERTY,
             EMBEDDED_PROPERTY,
-            LINKS_PROPERTY
+            LINKS_PROPERTY,
+            CORRECT_ANSWER_PROPERTY
         );
     }
 
@@ -199,7 +202,7 @@ public class DefaultAuthenticationResponse extends AbstractResource implements A
 
     @Override
     public Integer getCorrectAnswer() {
-        Map<String, Object> rawFactor = (Map<String, Object>) getEmbedded().get(NESTED__FACTOR_PROPERTY.getName());
+        Map<String, Object> rawFactor = (Map<String, Object>) getEmbedded().get(NESTED__FACTORS_PROPERTY.getName());
 
         if (rawFactor != null && rawFactor.containsKey(EMBEDDED_PROPERTY.getName())) {
             Map<String, Object> challengeFactorEmbedded = (Map<String, Object>) rawFactor.get(EMBEDDED_PROPERTY.getName());

--- a/impl/src/test/groovy/com/okta/authn/sdk/impl/resource/BulkResourceTest.groovy
+++ b/impl/src/test/groovy/com/okta/authn/sdk/impl/resource/BulkResourceTest.groovy
@@ -15,6 +15,7 @@
  */
 package com.okta.authn.sdk.impl.resource
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.okta.authn.sdk.impl.util.TestUtil
 import com.okta.commons.lang.Assert
 import com.okta.sdk.impl.ds.InternalDataStore
@@ -205,7 +206,8 @@ class BulkResourceTest {
                 resource.setProperty(property, "2001-07-04T12:08:56.235-0700")
             }
             else if (property instanceof MapProperty) {
-                resource.setProperty(property, [one: "two"])
+                String jsonStr = "{\"one\":\"two\",\"factors\":{\"_embedded\":{\"challenge\":{\"correctAnswer\":42}}}}";
+                resource.setProperty(property, new ObjectMapper().readValue(jsonStr, HashMap.class));
             }
             else if (property instanceof ResourceReference) {
                 resource.setProperty(property, [one: "two"])


### PR DESCRIPTION
## Problem Analysis (Technical)
Okta may see a particular login attempt as suspicious. In that case, the 3-number-verification challenge begins however, the `AuthenticationResponse` does not have a function to retrieve this code/number from the response

## Solution (Technical)
Added a function to retrieve the `correctAnswer` from the embedded factor response, required by the clients when the 3-number-verification challenge begins. The clients can then display the number to the user.

## Affected Components
AuthenticationResponse.java
DefaultAuthenticationResponse.java