### PR TITLE
OKTA-406538: Add activation link request to AuthenticationClient

### DIFF
--- a/api/src/main/java/com/okta/authn/sdk/client/AuthenticationClient.java
+++ b/api/src/main/java/com/okta/authn/sdk/client/AuthenticationClient.java
@@ -636,6 +636,33 @@ public interface AuthenticationClient {
     AuthenticationResponse resendVerifyFactor(String factorId, String stateToken, RequestContext requestContext, AuthenticationStateHandler stateHandler) throws AuthenticationException;
 
     /**
+     * Sends an activation email when the user is unable to scan the QR code provided as part of an Okta Verify transaction.
+     * If for any reason the user can't scan the QR code, they can use the link provided in email or SMS to complete the transaction.
+     *
+     * @param stateToken state token for current transaction
+     * @param stateHandler State handler that handles the resulting status change corresponding to the Okta authentication state machine
+     * @return An authentication response
+     * @throws AuthenticationException any other authentication related error
+     */
+    @ApiReference(path = "/api/v1/authn/factors/{factorId}/lifecycle/activate/email", href = "https://developer.okta.com/docs/reference/api/authn/#send-activation-links")
+    default AuthenticationResponse sendActivationEmail(String factorId, String stateToken, AuthenticationStateHandler stateHandler) throws AuthenticationException {
+        return sendActivationEmail(factorId, stateToken, null, stateHandler);
+    }
+
+    /**
+     * Sends an activation email when the user is unable to scan the QR code provided as part of an Okta Verify transaction.
+     * If for any reason the user can't scan the QR code, they can use the link provided in email or SMS to complete the transaction.
+     *
+     * @param stateToken state token for current transaction
+     * @param requestContext additional request headers and query parameters used for this request
+     * @param stateHandler State handler that handles the resulting status change corresponding to the Okta authentication state machine
+     * @return An authentication response
+     * @throws AuthenticationException any other authentication related error
+     */
+    @ApiReference(path = "/api/v1/authn/factors/{factorId}/lifecycle/activate/email", href = "https://developer.okta.com/docs/reference/api/authn/#send-activation-links")
+    AuthenticationResponse sendActivationEmail(String factorId, String stateToken, RequestContext requestContext, AuthenticationStateHandler stateHandler) throws AuthenticationException;
+
+    /**
      * Returns the state of factor's activation. Some factors (Push, Duo, etc) depend on a user action, this method can
      * be used to poll the state of the a factor's activation and transition to the next state when completed.
      *

--- a/api/src/main/java/com/okta/authn/sdk/client/AuthenticationClient.java
+++ b/api/src/main/java/com/okta/authn/sdk/client/AuthenticationClient.java
@@ -639,6 +639,7 @@ public interface AuthenticationClient {
      * Sends an activation email when the user is unable to scan the QR code provided as part of an Okta Verify transaction.
      * If for any reason the user can't scan the QR code, they can use the link provided in email or SMS to complete the transaction.
      *
+     * @param factorId id of factor returned from enrollment
      * @param stateToken state token for current transaction
      * @param stateHandler State handler that handles the resulting status change corresponding to the Okta authentication state machine
      * @return An authentication response
@@ -653,6 +654,7 @@ public interface AuthenticationClient {
      * Sends an activation email when the user is unable to scan the QR code provided as part of an Okta Verify transaction.
      * If for any reason the user can't scan the QR code, they can use the link provided in email or SMS to complete the transaction.
      *
+     * @param factorId id of factor returned from enrollment
      * @param stateToken state token for current transaction
      * @param requestContext additional request headers and query parameters used for this request
      * @param stateHandler State handler that handles the resulting status change corresponding to the Okta authentication state machine

--- a/impl/src/main/java/com/okta/authn/sdk/impl/client/DefaultAuthenticationClient.java
+++ b/impl/src/main/java/com/okta/authn/sdk/impl/client/DefaultAuthenticationClient.java
@@ -223,6 +223,11 @@ public class DefaultAuthenticationClient extends BaseClient implements Authentic
     }
 
     @Override
+    public AuthenticationResponse sendActivationEmail(String factorId, String stateToken, RequestContext requestContext, AuthenticationStateHandler stateHandler) throws AuthenticationException {
+        return doPost("/api/v1/authn/factors/" + factorId + "/lifecycle/activate/email", toRequest(stateToken), stateHandler, requestContext);
+    }
+
+    @Override
     public AuthenticationResponse verifyActivation(String factorId, String stateToken, RequestContext requestContext, AuthenticationStateHandler stateHandler) throws AuthenticationException {
         return doPost("/api/v1/authn/factors/" + factorId + "/lifecycle/activate/poll", toRequest(stateToken), stateHandler, requestContext);
     }

--- a/impl/src/test/groovy/com/okta/authn/sdk/impl/client/DefaultAuthenticationClientTest.groovy
+++ b/impl/src/test/groovy/com/okta/authn/sdk/impl/client/DefaultAuthenticationClientTest.groovy
@@ -178,6 +178,28 @@ class DefaultAuthenticationClientTest {
     }
 
     @Test
+    void sendActivationEmailTest() {
+        def client = createClient("sendActivationEmailTest")
+        StubRequestExecutor requestExecutor = client.getRequestExecutor()
+        String factorId = "factor321"
+
+        requestExecutor.requestMatchers.add(bodyMatches(
+            jsonObject()
+                .where("stateToken", is(jsonText("stateToken1")))
+        ))
+
+        requestExecutor.requestMatchers.add(
+            urlMatches(
+                endsWith("/api/v1/authn/factors/${factorId}/lifecycle/activate/email")
+            ))
+
+        def stateHandler = mock(AuthenticationStateHandler)
+        AuthenticationResponse response = client.sendActivationEmail(factorId, "stateToken1", stateHandler)
+        verify(stateHandler).handleMfaEnrollActivate(response)
+        assertThat response.factorResult, is("WAITING")
+    }
+
+    @Test
     void activationPollTest() {
         def client = createClient("activationPollTest")
         StubRequestExecutor requestExecutor = client.getRequestExecutor()

--- a/impl/src/test/resources/com/okta/authn/sdk/impl/client/DefaultAuthenticationClientTest/sendActivationEmailTest/api/v1/authn/factors/factor321/lifecycle/activate/email.json
+++ b/impl/src/test/resources/com/okta/authn/sdk/impl/client/DefaultAuthenticationClientTest/sendActivationEmailTest/api/v1/authn/factors/factor321/lifecycle/activate/email.json
@@ -1,0 +1,82 @@
+{
+  "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb",
+  "expiresAt": "2015-11-03T10:15:57.000Z",
+  "status": "MFA_ENROLL_ACTIVATE",
+  "factorResult": "WAITING",
+  "_embedded": {
+    "user": {
+      "id": "00ub0oNGTSWTBKOLGLNR",
+      "passwordChanged": "2015-09-08T20:14:45.000Z",
+      "profile": {
+        "login": "dade.murphy@example.com",
+        "firstName": "Dade",
+        "lastName": "Murphy",
+        "locale": "en_US",
+        "timeZone": "America/Los_Angeles"
+      }
+    },
+    "factor": {
+      "id": "opfh52xcuft3J4uZc0g3",
+      "factorType": "push",
+      "provider": "OKTA",
+      "_embedded": {
+        "activation": {
+          "expiresAt": "2015-11-03T10:15:57.000Z",
+          "_links": {
+            "qrcode": {
+              "href": "https://dev-259824.oktapreview.com/api/v1/users/00ub0oNGTSWTBKOLGLNR/factors/opfh52xcuft3J4uZc0g3/qr/00fukNElRS_Tz6k-CFhg3pH4KO2dj2guhmaapXWbc4",
+              "type": "image/png"
+            },
+            "send": [
+              {
+                "name": "email",
+                "href": "https://dev-259824.oktapreview.com/api/v1/users/00ub0oNGTSWTBKOLGLNR/factors/opfh52xcuft3J4uZc0g3/lifecycle/activate/email",
+                "hints": {
+                  "allow": [
+                    "POST"
+                  ]
+                }
+              },
+              {
+                "name": "sms",
+                "href": "https://dev-259824.oktapreview.com/api/v1/users/00ub0oNGTSWTBKOLGLNR/factors/opfh52xcuft3J4uZc0g3/lifecycle/activate/sms",
+                "hints": {
+                  "allow": [
+                    "POST"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "_links": {
+    "next": {
+      "name": "poll",
+      "href": "https://dev-259824.oktapreview.com/api/v1/authn/factors/opfh52xcuft3J4uZc0g3/lifecycle/activate/poll",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    },
+    "cancel": {
+      "href": "https://dev-259824.oktapreview.com/api/v1/authn/cancel",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    },
+    "prev": {
+      "href": "https://dev-259824.oktapreview.com/api/v1/authn/previous",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add an implementation of [Send activation links](https://developer.okta.com/docs/reference/api/authn/#send-activation-links) to AuthenticationClient wrapper for cases when the user is unable to scan the QR code provided as part of an Okta Verify transaction. If for any reason the user can't scan the QR code, they can use the link provided in email to complete the transaction during the multi-factor enrolment setup.

## Version
2.0.3-SNAPSHOT

## Issue(s)
https://github.com/okta/okta-auth-java/issues/107

## Category
- [ ] Bugfix
- [ ] Enhancement
- [x] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
