### PR TITLE
[Experiment] - use `zulu` vm for javadoc deployment instead of `adopt-openj9`

### DIFF
--- a/.github/workflows/development_javadoc.yml
+++ b/.github/workflows/development_javadoc.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 8
-          distribution: adopt-openj9
+          distribution: zulu
           cache: maven
 
       - name: Build Javadoc for Development version


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please see https://www.okta.com/vulnerability-reporting-policy/ or contact security@okta.com
-->

<!--
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).

Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->
## Summary

`adopt-openj9` VM crashes on Javadoc deployment on master builds. Hence changing it to `zulu` and experimenting if it would work.

![image](https://user-images.githubusercontent.com/61501885/160639107-c8e0e5b4-be3b-4fb2-b6e8-f7d27bc263a5.png)

Ref: https://github.com/actions/setup-java#supported-distributions

## Actual Behavior

<!-- 
Please describe step by step the behavior you are observing
-->

## Expected Behavior

<!--
Please describe step by step the behavior you expect
-->

## Configuration

<!--
Please provide any configuration you have.
-->

## Version

<!--
Please describe what version you are using. Does the problem occur in other versions?
-->

## Sample

<!--
Providing a complete sample (i.e. link to a github repository) will give this issue higher
priority than issues that do not have a complete sample.
-->

## Issue(s)
<!-- Reference any existing issue(s) here. -->

## Description
<!-- Add a brief description of the issue. -->

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
