### PR TITLE
OKTA-595542: Avoid possibility of null in switch statement (pre Java 18)

### DIFF
--- a/impl/src/main/java/com/okta/authn/sdk/impl/client/DefaultAuthenticationClient.java
+++ b/impl/src/main/java/com/okta/authn/sdk/impl/client/DefaultAuthenticationClient.java
@@ -54,6 +54,7 @@ import com.okta.authn.sdk.resource.FactorType;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -319,6 +320,10 @@ public class DefaultAuthenticationClient extends BaseClient implements Authentic
     private void translateException(ResourceException resourceException) throws AuthenticationException {
 
         String errorCode = resourceException.getCode();
+
+        if (Objects.isNull(errorCode)) {
+            throw resourceException;
+        }
 
         switch (errorCode) {
             case AuthenticationFailureException.ERROR_CODE:


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please see https://www.okta.com/vulnerability-reporting-policy/ or contact security@okta.com
-->

<!--
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).

Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->
## Summary

#193

`null` in switch statement is not allowed until Java 18 (https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html). 

## Actual Behavior

<!-- 
Please describe step by step the behavior you are observing
-->

## Expected Behavior

<!--
Please describe step by step the behavior you expect
-->

## Configuration

<!--
Please provide any configuration you have.
-->

## Version

<!--
Please describe what version you are using. Does the problem occur in other versions?
-->

## Sample

<!--
Providing a complete sample (i.e. link to a github repository) will give this issue higher
priority than issues that do not have a complete sample.
-->

## Issue(s)
<!-- Reference any existing issue(s) here. -->

## Description
<!-- Add a brief description of the issue. -->

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
