### PR TITLE
Upgrade tomcat-embed-core to 11.0.6 to address Snyk vulnerabilities

### DIFF
--- a/examples/example-webapp/pom.xml
+++ b/examples/example-webapp/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <java.version>17</java.version>
         <springboot.version>3.4.2</springboot.version>
-        <tomcat.embed.version>11.0.5</tomcat.embed.version>
+        <tomcat.embed.version>11.0.6</tomcat.embed.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This PR upgrades the `org.apache.tomcat.embed:tomcat-embed-core` dependency from version `11.0.5` to `11.0.6` to address critical security vulnerabilities identified by Snyk.