### PR TITLE
Bumping up commons-beanutils to version 1.11.0

### DIFF
--- a/examples/shiro-mustache/pom.xml
+++ b/examples/shiro-mustache/pom.xml
@@ -107,6 +107,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-assets</artifactId>
         </dependency>


### PR DESCRIPTION
This PR updates the ocommons-beanutils to version 1.11.0 to remediate multiple vulnerabilities identified by Snyk.