### PR TITLE
Upgrade tomcat-embed-core to 11.0.9 to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
                 <artifactId>okio-jvm</artifactId>
                 <version>3.11.0</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>11.0.9</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This PR upgrades the transitive dependency `tomcat-embed-core` to version `11.0.9` via the parent POM to resolve known security vulnerabilities.
These were identified by Snyk in version 11.0.6. Version 11.0.9 contains the required security patches.
